### PR TITLE
Tweak rules for `eslint-plugin-import`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,24 @@ const { handledByPrettier } = require(`./handled-by-prettier.js`);
 
 /** @type {import("eslint").Linter.Config} */
 const config = {
+  overrides: [
+    {
+      files: [
+        // Next.js API routes.
+        `*.handler.ts`,
+
+        // Next.js pages.
+        `*.page.tsx`,
+
+        // Storybook stories.
+        `*.stories.tsx`,
+      ],
+      rules: {
+        'import/no-default-export': `off`,
+      },
+    },
+  ],
+
   plugins: [`import`, `simple-import-sort`, `sort-destructure-keys`],
 
   rules: {
@@ -21,6 +39,19 @@ const config = {
     'import/consistent-type-specifier-style': [`error`, `prefer-top-level`],
     'import/extensions': [`error`, `ignorePackages`],
     'import/no-default-export': [`error`],
+
+    'import/no-extraneous-dependencies': [
+      `error`,
+      {
+        devDependencies: [
+          `**/*.spec.js`,
+          `**/*.spec.ts`,
+          `**/*.test.js`,
+          `**/*.test.ts`,
+        ],
+      },
+    ],
+
     'import/prefer-default-export': `off`,
 
     'no-await-in-loop': `off`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@percuss.io/eslint-config-ericcarraway",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@percuss.io/eslint-config-ericcarraway",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "ISC",
       "peerDependencies": {
         "eslint": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percuss.io/eslint-config-ericcarraway",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Shareable ESLint config for percuss.io JavaScript projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Disable `import/no-default-export` for Next.js & Storybook, which require certain files to have a default export.
- Configure `import/no-extraneous-dependencies` so that `vitest` can be in `devDependencies` rather than `dependencies`.
- Publish version 2.1.0 on NPM https://www.npmjs.com/package/@percuss.io/eslint-config-ericcarraway
